### PR TITLE
updated mdapi url fixes GClunies/py_noaa#40

### DIFF
--- a/noaa_coops/noaa_coops.py
+++ b/noaa_coops/noaa_coops.py
@@ -56,7 +56,7 @@ class Station:
         initialized, fill out metadata automatically.
         """
 
-        metadata_base_url = ('http://tidesandcurrents.noaa.gov/mdapi/v1.0/'
+        metadata_base_url = ('https://api.tidesandcurrents.noaa.gov/mdapi/prod/'
                              'webapi/stations/')
         extension = '.json'
         metadata_expand = ('?expand=details,sensors,products,disclaimers,'


### PR DESCRIPTION
The url used is outdated per email from the noaa team:

> Based on the information that you have provided in your message, it appears that you are using an outdated URL access to the MetaData API.
> 
> The correct URLS to our APIs are:
> 
> MetaDataAPI (MDAPI):  https://api.tidesandcurrents.noaa.gov/mdapi/prod/
> 
> Data API:  https://api.tidesandcurrents.noaa.gov/api/prod/
> 
> DerivedProducts (DPAPI):  https://api.tidesandcurrents.noaa.gov/dpapi/prod/
> 
> 
> Please Also Note:
> We are in the process of transitioning our website and online data services (including the APIs) from an internal server to a cloud server.
> During this transition process there may be intermittent interruptions in data access as we work through issues of this transition.
> We are working to keep interruptions to a minimum during this process. 
> We apologize for any inconvenience this may cause.



The following is the output of running python3 noaa_coops.py after the change
> Test that metadata is working
> {'units': 'feet', 'sensors': [{'status': 1, 'refdatum': '', 'sensorID': 'U1', 'name': 'Tsunami WL', 'elevation': None, 'message': '', 'dcp': 3}, {'status': 1, 'refdatum': '', 'sensorID': 'Y1', 'name': 'Microwave WL', 'elevation': None, 'message': '', 'dcp': 3}, {'status': 1, 'refdatum': 'MSL', 'sensorID': 'site', 'name': 'site', 'elevation': 12.48063, 'message': '', 'dcp': 0}], 'self': 'https://tidesandcurrents.noaa.gov/mdapi/latest/webapi/stations/9447130/sensors.json'}
> 
> 
> Test that data_inventory is working
> {'Wind': {'start_date': '1991-11-09 00:00', 'end_date': '2019-01-02 18:36'}, 'Air Temperature': {'start_date': '1991-11-09 01:00', 'end_date': '2019-01-02 18:36'}, 'Water Temperature': {'start_date': '1991-11-09 00:00', 'end_date': '2019-01-02 18:36'}, 'Barometric Pressure': {'start_date': '1991-11-09 00:00', 'end_date': '2019-01-02 18:36'}, 'Preliminary 6-Minute Water Level': {'start_date': '2001-01-01 00:00', 'end_date': '2020-08-05 15:30'}, 'Verified 6-Minute Water Level': {'start_date': '1995-06-01 00:00', 'end_date': '2020-06-30 23:54'}, 'Verified Hourly Height Water Level': {'start_date': '1899-01-01 00:00', 'end_date': '2020-06-30 23:00'}, 'Verified High/Low Water Level': {'start_date': '1979-10-01 06:24', 'end_date': '2020-06-30 23:54'}, 'Verified Monthly Mean Water Level': {'start_date': '1898-12-01 00:00', 'end_date': '2020-06-30 23:54'}}