### PR TITLE
Package Publishing testing

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.7
+current_version = 0.1.8
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 0.1.7
 commit = True
-tag = false
+tag = True
 
 [bumpversion:file:setup.py]
 

--- a/noaa_coops/__init__.py
+++ b/noaa_coops/__init__.py
@@ -1,4 +1,4 @@
 import noaa_coops  # noqa: F401
 from noaa_coops.noaa_coops import Station  # noqa: F401
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 
 [metadata]
 name = noaa_coops
-version = 0.1.7
+version = 0.1.8
 author = Greg Clunies
 author-email = greg.clunies@gmail.com
 home-page = https://github.com/GClunies/noaa_coops

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="noaa_coops",
-    version="0.1.7",
+    version="0.1.8",
     description="Python wrapper for NOAA Tides & Currents Data and Metadata",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR:

1. Introduces [Github Action](https://github.com/features/actions) Workflows that help with package testing and publishing to pypi. These Github Actions will replace the testing checks currently implemented by [Travis-CI](https://travis-ci.com/github/GClunies/noaa_coops)
    - `.github/workflows/publish-to-test-pypi.yml` to define the Github CI/CD action process
1. Add config files to help with development:
    - `environment.yml` conda environment for local development
    - `.envrc` to be used with [direnv](https://direnv.net/) so that the conda env is activated when you `cd` into repo
    - `Makefile` to help with code formatting using `black` and linting using `flake8`
    - `mypy.ini` for type checking (not being used right now)
    - `pyproject.toml` used by `black` and for the Github CI/CD action `[build-system]`
    - `setup.cfg` so that the Github CI/CD Action can build the `noaa_coops` package using `pep517.build` instead of `twine`