### PR TITLE
Fix minor bug in _parse_known_date_formats

### DIFF
--- a/noaa_coops/station.py
+++ b/noaa_coops/station.py
@@ -512,11 +512,12 @@ class Station:
             try:
                 return datetime.strptime(dt_string, fmt)
             except ValueError:
-                raise ValueError(
-                    "No valid date format found."
-                    "See https://tidesandcurrents.noaa.gov/api/ "
-                    "for list of accepted date formats."
-                )
+                pass
+        raise ValueError(
+            "No valid date format found."
+            "See https://tidesandcurrents.noaa.gov/api/ "
+            "for list of accepted date formats."
+        )
 
     def get_data(
         self,


### PR DESCRIPTION
Hello! Big fan of the package. 

During commit 83e60e3, a small bug was introduced that removed the ability for `_parse_known_date_formats()` to accept the last three possible datetime formats. I noticed this when I updated the package and lost the ability to specify `%H:%M`, because it raises a ValueError if the first format fails. This (very minor) PR keeps the updated docstring but moves the `raise` back outside the loop.