### PR TITLE
Relax dependency versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1209,4 +1209,4 @@ xmlsec = ["xmlsec (>=0.6.1)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "6c567309d3ca37db874a35b409ba17409fd943d279a6d2b75745eac8dd58af2f"
+content-hash = "90852e0e8be6e460c56983be1ab7addf6fcd3b4125e0122c943e83a296aef7ba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,9 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-requests = "^2.32.3"
-pandas = "^2.2.2"
-zeep = "^4.2.1"
+requests = ">=2.32.3"
+pandas = ">=2.2.2"
+zeep = ">=4.2.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.2"


### PR DESCRIPTION
Relax the dependency version ranges to allow the install of pandas `3.0` which will be released soonish. The library only uses common functions which are unlikely to break with the next release. _This will also help facilitate the adoption of Python 3.14 as pandas 3.0 will likely be the first fully supported version._

The general suggestion in the packaging ecosystem is that libraries should only specify lower bounds, unless strictly necessary, to make it easier for downstream packages and applications.

_It would be awesome if a new could be released after this is merged so downstream packages can be ready for the pandas bump._