### PR TITLE
feat: add CITATION.cff for software citation support

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,21 @@
+cff-version: 1.2.0
+title: noaa_coops
+message: "If you use this software, please cite it as below."
+type: software
+authors:
+  - family-names: Clunies
+    given-names: Gregory
+    github: GClunies
+repository-code: "https://github.com/GClunies/noaa_coops"
+url: "https://github.com/GClunies/noaa_coops"
+license: LICENSE
+abstract: >
+  A Python wrapper for the NOAA CO-OPS Tides & Currents data APIs,
+  enabling easy access to oceanographic and tidal data.
+keywords:
+  - NOAA
+  - tides
+  - currents
+  - oceanography
+  - python
+  - API


### PR DESCRIPTION
Closes #67

## What does this PR do?
Adds a CITATION.cff file to the repository so that users can easily 
cite the noaa_coops package in academic manuscripts and research papers.

## Why?
As requested in issue #67, a user wanted to cite this package 
in a manuscript but there was no standard citation format available.

## References
- https://citation-file-format.github.io/