### PR TITLE
Add error handling for station API request

### DIFF
--- a/noaa_coops/station.py
+++ b/noaa_coops/station.py
@@ -41,6 +41,12 @@ def get_stations_from_bbox(
     station_list = []
     data_url = "https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json"
     response = requests.get(data_url)
+
+    if response.status_code != 200:
+        raise COOPSAPIError(
+             f"Failed to fetch station list. Status code: {response.status_code}"
+    )
+
     json_dict = response.json()
 
     if len(lat_coords) != 2 or len(lon_coords) != 2:


### PR DESCRIPTION
Added error handling for special APIs request in get_stations_from_bbox().
Previously the function assumed a successful API response.
Now it checks the response status code and raises COOPSAPIError if the request fails. 