### PR TITLE
Expose additional metadata fields (details, bins, deployments)

### DIFF
--- a/noaa_coops/station.py
+++ b/noaa_coops/station.py
@@ -145,6 +145,11 @@ class Station:
         response = requests.get(metadata_url)
         json_dict = response.json()
         station_metadata = json_dict["stations"][0]
+        # Expose additional useful metadata fields
+        self.details = station_metadata.get("details", {})
+        self.bins = station_metadata.get("bins", [])
+        self.deployments = station_metadata.get("deployments", [])
+
 
         # Set class attributes base on provided metadata
         if "datums" in station_metadata:  # if True --> water levels


### PR DESCRIPTION
This PR exposes additional metadata fields returned by the NOAA CO-OPS
metadata API.

The API already provides the fields:
- details
- bins
- deployments

However these were only accessible through the raw `station.metadata`
dictionary. This change adds them as attributes of the `Station` object
for easier access.

Using `.get()` ensures compatibility with stations where these fields
may not exist.