### PR TITLE
docs + SOAP retry: README overhaul, CONTRIBUTING, CHANGELOG, issue + PR templates, retrying SOAP session

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Something isn't working as expected.
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: >
+        A clear description of what you expected vs. what actually happened.
+      placeholder: |
+        I called Station.get_data(...) for 2015 water levels and got …
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Minimal Python snippet that reproduces the issue.
+      render: python
+      placeholder: |
+        from noaa_coops import Station
+        seattle = Station(id="9447130")
+        df = seattle.get_data(
+            begin_date="20150101",
+            end_date="20150131",
+            product="water_level",
+            datum="MLLW",
+            units="metric",
+            time_zone="gmt",
+        )
+    validations:
+      required: true
+
+  - type: input
+    id: noaa-coops-version
+    attributes:
+      label: noaa-coops version
+      placeholder: "0.5.0"
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      description: Output of `python --version`.
+      placeholder: "Python 3.12.0"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "macOS 14 / Ubuntu 24.04 / Windows 11 / ..."
+
+  - type: textarea
+    id: traceback
+    attributes:
+      label: Full traceback (if applicable)
+      render: text

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: Suggest a new capability or a change to an existing one.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: >
+        Describe the use case or the situation that the feature would make
+        easier. What are you doing today to work around it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: >
+        What would the API look like? A short example is worth more than a
+        description.
+      render: python
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other ways to solve the problem you've thought about.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What changed and why. 1-3 sentences. -->
+
+## Changes
+
+<!-- Bulleted list of notable changes. -->
+
+## Test plan
+
+- [ ] `uv run pytest` passes
+- [ ] `uv run ruff check .` / `uv run ruff format --check .` clean
+- [ ] `uv run mypy noaa_coops` clean
+- [ ] New behavior has test coverage
+- [ ] CHANGELOG.md updated under `[Unreleased]`
+
+## Notes
+
+<!-- Anything reviewers should know: breaking changes, follow-ups, deferred items. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- SOAP `DataInventory` calls now go through a dedicated retrying
+  `requests.Session` (`_SOAP_SESSION`) that retries POST as well as GET on
+  transient failures (`429`/`5xx`). Gives the data-inventory path the same
+  resiliency the REST path already had.
+
 ## [0.5.0]
 
 Major modernization release. Every layer of the project was touched — build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,111 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+## [0.5.0]
+
+Major modernization release. Every layer of the project was touched — build
+system, CI/CD, internal structure, testing, and docs. Behavior for existing
+users is almost entirely unchanged; two small backward-compatible behavioral
+changes are called out under *Changed* below.
+
+### Added
+
+- **Module-level HTTP session** with automatic retries on transient failures
+  (`429`, `500`, `502`, `503`, `504`) via a `urllib3.util.retry.Retry` adapter
+  (`noaa_coops/_http.py`). All calls — including `get_stations_from_bbox` —
+  share the session's connection pool and retry policy.
+- **Warn-and-continue** behavior on multi-block fetches: when one block in a
+  multi-month fetch fails, a `RuntimeWarning` is emitted and
+  `df.attrs["missing_blocks"]` is populated with `{begin, end, error}` entries
+  instead of silently dropping the block.
+- **Declarative product registry** (`noaa_coops/_products.py`) replacing the
+  historical 186-line `_check_product_params` if/elif tree + 150-line
+  `_build_request_url` if/elif tree. Adding a new NOAA product is now a
+  one-place change.
+- **Public export**: `COOPSAPIError` is now importable as
+  `from noaa_coops import COOPSAPIError` (the old
+  `from noaa_coops.station import COOPSAPIError` path still works).
+- **Offline test suite** using [pytest-recording](https://github.com/kiwicom/pytest-recording)
+  VCR cassettes. Default `pytest` runs in ~1.5s with zero network calls.
+- **Nightly live canary** (`.github/workflows/nightly.yml`) runs `pytest -m
+  live` daily at 06:00 UTC. On failure, opens a tracking issue so NOAA drift
+  is visible without flooding the inbox.
+- **Manual publish workflows** mirroring the PyPA pattern:
+  `.github/workflows/test-publish.yml` publishes to TestPyPI,
+  `.github/workflows/publish.yml` publishes to PyPI + creates the
+  `v{VERSION}` tag + cuts a GitHub Release with an auto-generated changelog
+  from `git log`. Both `workflow_dispatch`.
+- **Dependabot** configured for `github-actions` and the `uv` ecosystems.
+- **pre-commit** hooks (`.pre-commit-config.yaml`) — ruff check + format +
+  standard hygiene hooks. Free auto-fix PRs via pre-commit.ci.
+
+### Changed
+
+- **Build backend swapped to hatchling.** Version is read from
+  `noaa_coops/__init__.py` by `hatchling.build`. No more `poetry-core`.
+- **CI swapped to `uv` + `hatchling`.** Jobs: `lint` (ruff), `typecheck`
+  (mypy), and `test` (pytest matrix across Python 3.10 – 3.13 on
+  `ubuntu-latest`).
+- **Added HTTP timeouts everywhere.** Every `requests.get` / `_SESSION.get`
+  passes `timeout=(5.0, 30.0)` (connect, read). No more hangs on stalled NOAA
+  endpoints.
+- **Narrower exception handling.** Bare `except:` in `Station.__init__`
+  replaced with `(requests.RequestException, zeep.exceptions.Error,
+  AttributeError, TypeError)` + a `logging.warning`. `KeyboardInterrupt` and
+  `SystemExit` now propagate correctly.
+- **Internal module split.** `station.py` shrunk from 825 lines to ~350.
+  New internal modules: `_exceptions.py`, `_endpoints.py`, `_http.py`,
+  `_parsing.py`, `_products.py`, `_metadata.py`, plus the public `api.py`.
+  All previous import paths continue to work.
+- **`pyproject.toml` converted to PEP 621** `[project]` table with
+  classifiers, keywords, and `[project.urls]` so the PyPI page renders useful
+  metadata.
+- **`station.data_inventory` is always set.** An empty dict `{}` now
+  indicates the SOAP fetch failed, rather than the attribute being unset.
+  Callers using `hasattr(station, 'data_inventory')` should switch to
+  `if not station.data_inventory:`.
+
+### Fixed
+
+- **O(n²) memory in multi-block fetches.** The multi-block loop used to
+  rebuild the full DataFrame on every iteration via
+  `df = pd.concat([df, df_block])`. Now appends to a list and concatenates
+  once at the end.
+- **Silent `KeyError` crash in `get_data_inventory`.** If the SOAP response
+  lacked a `"parameter"` key, the error escaped the narrow catch in
+  `Station.__init__` and crashed construction. Now handled locally via
+  `try/except (KeyError, TypeError)`.
+- **`_parse_known_date_formats` `UnboundLocalError` trap.** The old
+  `match = False` flag pattern (set only in the `except` branch) could raise
+  `UnboundLocalError` in edge cases. Rewritten as a clean for/try/continue
+  loop that raises `ValueError` after exhausting all known formats.
+- **`stale --cov=reflekt` config.** pytest coverage was pointing at the
+  wrong project. Fixed to `--cov=noaa_coops`.
+
+### Removed
+
+- **Python 3.9 support.** 3.9 went EOL in October 2025 and the modern testing
+  stack (vcrpy 8.x, urllib3 2.x, types-requests 2.32.4+) requires ≥3.10.
+  Supported versions: 3.10, 3.11, 3.12, 3.13.
+- **Dead files.** `.bumpversion.cfg` (stuck at `0.1.9` targeting nonexistent
+  `setup.py`), `.flake8` (superseded by ruff), `mypy.ini` (migrated into
+  `pyproject.toml`), `pytest.ini` (same), old `poetry.lock`, and a 96-line
+  `if __name__ == "__main__":` debug block in `station.py`.
+- **Third-party publish action.** Replaced `JRubics/poetry-publish` with the
+  PyPA-official `pypa/gh-action-pypi-publish`.
+
+## [0.4.0] - 2023-xx-xx
+
+Earlier releases are documented in the
+[GitHub release history](https://github.com/GClunies/noaa_coops/releases).
+
+<!-- Links -->
+[Unreleased]: https://github.com/GClunies/noaa_coops/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/GClunies/noaa_coops/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/GClunies/noaa_coops/releases/tag/v0.4.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,13 +2,14 @@ cff-version: 1.2.0
 title: noaa_coops
 message: "If you use this software, please cite it as below."
 type: software
+version: "0.5.0"
 authors:
   - family-names: Clunies
     given-names: Gregory
     github: GClunies
 repository-code: "https://github.com/GClunies/noaa_coops"
 url: "https://github.com/GClunies/noaa_coops"
-license: LICENSE
+license: Apache-2.0
 abstract: >
   A Python wrapper for the NOAA CO-OPS Tides & Currents data APIs,
   enabling easy access to oceanographic and tidal data.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing
+
+Thanks for wanting to contribute.
+
+## Development environment
+
+This project uses [uv](https://docs.astral.sh/uv/) and [hatchling](https://hatch.pypa.io/latest/).
+Install `uv`, then:
+
+```bash
+git clone https://github.com/GClunies/noaa_coops.git
+cd noaa_coops
+uv sync --locked --all-extras --group dev
+```
+
+That creates a `.venv/` and installs the runtime deps plus the dev toolchain
+(`pytest`, `pytest-cov`, `pytest-recording`, `mypy`, `ruff`, `responses`,
+type stubs).
+
+## Running tests
+
+```bash
+# Default: offline, deterministic, <2s. Replays recorded VCR cassettes.
+uv run pytest
+
+# Run the nightly live canary locally (hits the real NOAA API):
+uv run pytest -m live
+
+# Re-record cassettes after intentional NOAA drift or a new test:
+uv run pytest --record-mode=rewrite           # rebuild every cassette
+uv run pytest --record-mode=new_episodes      # record only new calls
+```
+
+Cassettes live at `tests/cassettes/test_station/*.yaml`. Commit them
+alongside any test changes that touch the live path.
+
+## Lint, format, typecheck
+
+```bash
+uv run ruff check .
+uv run ruff format .
+uv run mypy noaa_coops
+```
+
+These all run in CI on every PR. Pre-commit is also wired up via
+[pre-commit.ci](https://pre-commit.ci) — style issues get auto-fixed on
+inbound PRs.
+
+## Pull request checklist
+
+Before requesting review:
+
+- [ ] Tests pass: `uv run pytest`
+- [ ] Ruff clean: `uv run ruff check .` and `uv run ruff format --check .`
+- [ ] Mypy clean: `uv run mypy noaa_coops`
+- [ ] New or modified behavior has test coverage
+- [ ] If you touched the live API path, re-recorded cassettes
+- [ ] PR description explains the why, not just the what
+
+## Release process
+
+Releases are cut manually via the GitHub Actions UI.
+
+1. Bump `__version__` in `noaa_coops/__init__.py` (e.g. `0.5.0` → `0.6.0`).
+2. Update `CHANGELOG.md` — move the **Unreleased** section under the new
+   version with today's date, and start a fresh `## [Unreleased]` header.
+3. PR, review, merge to `master`.
+4. Actions → **Test Publish** → *Run workflow*. Confirms the wheel installs
+   cleanly from TestPyPI.
+5. Actions → **Publish** → *Run workflow*. Publishes to PyPI, creates the
+   `v{VERSION}` git tag, and cuts a GitHub Release with a changelog
+   auto-generated from `git log $PREV_TAG..HEAD`.
+
+Each step validates semver format and refuses to run if the tag already
+exists.
+
+## Nightly canary
+
+`.github/workflows/nightly.yml` runs `pytest -m live` on a daily cron. If it
+fails, it opens (or updates) a `nightly-canary`-labeled issue — real NOAA
+drift is visible without spamming the inbox.
+
+## Reporting bugs
+
+Open an [issue](https://github.com/GClunies/noaa_coops/issues) with the bug
+report template. Include the Python version, `noaa_coops` version, and a
+minimal reproduction.

--- a/README.md
+++ b/README.md
@@ -1,103 +1,95 @@
 # noaa_coops
 
-[![PyPI](https://img.shields.io/pypi/v/noaa_coops.svg)](https://pypi.python.org/pypi/noaa-coops)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/noaa_coops.svg)](https://pypi.python.org/pypi/noaa-coops)
+[![CI](https://github.com/GClunies/noaa_coops/actions/workflows/pull_request.yml/badge.svg)](https://github.com/GClunies/noaa_coops/actions/workflows/pull_request.yml)
+[![PyPI](https://img.shields.io/pypi/v/noaa-coops.svg)](https://pypi.python.org/pypi/noaa-coops)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/noaa-coops.svg)](https://pypi.python.org/pypi/noaa-coops)
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](https://github.com/GClunies/noaa_coops/blob/master/LICENSE)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/GClunies/noaa_coops/master.svg)](https://results.pre-commit.ci/latest/github/GClunies/noaa_coops/master)
 
-A Python wrapper for the NOAA CO-OPS Tides &amp; Currents [Data](https://tidesandcurrents.noaa.gov/api/)
-and [Metadata](https://tidesandcurrents.noaa.gov/mdapi/latest/) APIs.
+A Python wrapper for the NOAA CO-OPS Tides & Currents
+[Data](https://tidesandcurrents.noaa.gov/api/) and
+[Metadata](https://tidesandcurrents.noaa.gov/mdapi/latest/) APIs.
 
 ## Installation
-This package is distributed via [PyPi](https://pypi.org/project/noaa-coops/) and can be installed using , `pip`, `poetry`, etc.
-```bash
-# Install with pip
-❯ pip install noaa_coops
 
-# Install with poetry
-❯ poetry add noaa_coops
+Supported on Python **3.10, 3.11, 3.12, and 3.13**.
+
+```bash
+uv add noaa-coops
 ```
 
-## Getting Started
+## Getting started
 
 ### Stations
-Data is accessed via `Station` class objects. Each station is uniquely identified by an `id`. To initialize a `Station` object, run:
+
+Data is accessed via `Station` objects identified by a NOAA station `id`:
 
 ```python
 >>> from noaa_coops import Station
->>> seattle = Station(id="9447130")  # Create Station object for Seattle (ID = 9447130)
+>>> seattle = Station(id="9447130")  # Seattle, WA
 ```
 
-Stations and their IDs can be found using the Tides & Currents [mapping interface](https://tidesandcurrents.noaa.gov/). Alternatively, you can search for stations in a bounding box using the `get_stations_from_bbox` function, which will return a list of stations found in the box (if any).
+Find station IDs via the NOAA
+[Tides & Currents mapping interface](https://tidesandcurrents.noaa.gov/) or
+search by bounding box:
+
 ```python
->>> from pprint import pprint
->>> from noaa_coops import Station, get_stations_from_bbox
->>> stations = get_stations_from_bbox(lat_coords=[40.389, 40.9397], lon_coords=[-74.4751, -73.7432])
->>> pprint(stations)
+>>> from noaa_coops import get_stations_from_bbox, Station
+>>> stations = get_stations_from_bbox(
+...     lat_coords=[40.389, 40.9397],
+...     lon_coords=[-74.4751, -73.7432],
+... )
+>>> stations
 ['8516945', '8518750', '8519483', '8531680']
->>> station_one = Station(id="8516945")
->>> pprint(station_one.name)
+>>> Station(id="8516945").name
 'Kings Point'
 ```
 
 ### Metadata
-Station metadata is stored in the `.metadata` attribute of a `Station` object. Additionally, the keys of the metadata attribute dictionary are also assigned as attributes of the station object itself.
+
+Station metadata lives on the `.metadata` attribute, and individual fields are
+also promoted to top-level attributes on the `Station` object:
 
 ```python
->>> from pprint import pprint
->>> from noaa_coops import Station
 >>> seattle = Station(id="9447130")
->>> pprint(list(seattle.metadata.items())[:5])                   # Print first 3 items in metadata
-[('tidal', True), ('greatlakes', False), ('shefcode', 'EBSW1')]  # Metadata dictionary can be very long
->>> pprint(seattle.lat_lon['lat'])                               # Print latitude
-47.601944
->>> pprint(seattle.lat_lon['lon'])                               # Print longitude
--122.339167
+>>> seattle.name
+'Seattle'
+>>> seattle.state
+'WA'
+>>> seattle.lat_lon
+{'lat': 47.601944, 'lon': -122.339167}
 ```
 
-### Data Inventory
-A description of a Station's data products and available dates can be accessed via the `.data_inventory` attribute of a `Station` object.
+### Data inventory
+
+Per-product first/last observation dates:
 
 ```python
->>> from noaa_coops import Station
->>> from pprint import pprint
->>> seattle = Station(id="9447130")
->>> pprint(seattle.data_inventory)
-{'Air Temperature': {'end_date': '2019-01-02 18:36',
-                     'start_date': '1991-11-09 01:00'},
- 'Barometric Pressure': {'end_date': '2019-01-02 18:36',
-                         'start_date': '1991-11-09 00:00'},
- 'Preliminary 6-Minute Water Level': {'end_date': '2023-02-05 19:54',
-                                      'start_date': '2001-01-01 00:00'},
- 'Verified 6-Minute Water Level': {'end_date': '2022-12-31 23:54',
-                                   'start_date': '1995-06-01 00:00'},
- 'Verified High/Low Water Level': {'end_date': '2022-12-31 23:54',
-                                   'start_date': '1977-10-18 02:18'},
- 'Verified Hourly Height Water Level': {'end_date': '2022-12-31 23:00',
-                                        'start_date': '1899-01-01 00:00'},
- 'Verified Monthly Mean Water Level': {'end_date': '2022-12-31 23:54',
-                                       'start_date': '1898-12-01 00:00'},
- 'Water Temperature': {'end_date': '2019-01-02 18:36',
-                       'start_date': '1991-11-09 00:00'},
- 'Wind': {'end_date': '2019-01-02 18:36', 'start_date': '1991-11-09 00:00'}}
+>>> seattle.data_inventory["Wind"]
+{'start_date': '1991-11-09 00:00', 'end_date': '...'}
 ```
 
-### Data Retrieval
-Available data products can be found in NOAA CO-OPS Data API docs.
+> **Note:** The data inventory comes from NOAA's legacy SOAP endpoint and is
+> best-effort. If the service is unreachable, `data_inventory` is set to `{}`
+> and a warning is logged — `Station()` construction still succeeds.
 
-Station data can be fetched using the `.get_data` method on a `Station` object. Data is returned as a Pandas [DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) for ease of use and analysis. DataFrame columns are named according to the NOAA CO-OPS API [docs](https://api.tidesandcurrents.noaa.gov/api/prod/responseHelp.html), with the `t` column (timestamp) set as the DataFrame index.
+### Data retrieval
 
-The example below fetches water level data from the Seattle station (id=9447130) for a 1 month period. The corresponding [web output](https://tidesandcurrents.noaa.gov/waterlevels.html?id=9447130&units=metric&bdate=20150101&edate=20150131&timezone=GMT&datum=MLLW) is shown below the code as a reference.
+Data is returned as a pandas `DataFrame` indexed by timestamp. Column names
+mirror NOAA's [response format](https://api.tidesandcurrents.noaa.gov/api/prod/responseHelp.html).
 
 ```python
->>> from noaa_coops import Station
 >>> seattle = Station(id="9447130")
->>> df_water_levels = seattle.get_data(
+>>> df = seattle.get_data(
 ...     begin_date="20150101",
 ...     end_date="20150131",
 ...     product="water_level",
 ...     datum="MLLW",
 ...     units="metric",
-...     time_zone="gmt")
->>> df_water_levels.head()
+...     time_zone="gmt",
+... )
+>>> df.head()
                          v      s        f  q
 t
 2015-01-01 00:00:00  1.799  0.023  0,0,0,0  v
@@ -105,23 +97,51 @@ t
 2015-01-01 00:12:00  1.639  0.013  0,0,0,0  v
 2015-01-01 00:18:00  1.557  0.012  0,0,0,0  v
 2015-01-01 00:24:00  1.473  0.014  0,0,0,0  v
-
 ```
 
-![image](https://user-images.githubusercontent.com/28986302/233147224-765fbe05-372c-40f3-8bbe-4102536e7ff3.png)
+![Water levels chart](https://user-images.githubusercontent.com/28986302/233147224-765fbe05-372c-40f3-8bbe-4102536e7ff3.png)
 
+Multi-month and multi-year ranges are automatically split into 31-day (or
+365-day for `hourly_height` / `high_low`) blocks and concatenated. If NOAA
+fails to return data for a block, you get a partial DataFrame along with a
+`RuntimeWarning` and a `df.attrs["missing_blocks"]` list describing which
+ranges failed — downstream code can detect gaps instead of silently averaging
+across them.
 
-## Development
+### Supported arguments
 
-### Requirements
-This package and its dependencies are managed using [poetry](https://python-poetry.org/). To install the development environment for `noaa_coops`, first install poetry, then run (inside the repo):
+Values accepted by `Station.get_data(...)` — see
+[NOAA's API docs](https://api.tidesandcurrents.noaa.gov/api/prod/#products) for
+the authoritative reference.
 
-```bash
-poetry install
-```
+| Argument    | Accepted values                                                                                                                                                                                     |
+|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `product`   | `water_level`, `hourly_height`, `high_low`, `daily_mean`, `monthly_mean`, `one_minute_water_level`, `predictions`, `datums`, `air_gap`, `air_temperature`, `water_temperature`, `wind`, `air_pressure`, `conductivity`, `visibility`, `humidity`, `salinity`, `currents`, `currents_predictions`, `ofs_water_level` |
+| `datum`     | `CRD`, `IGLD`, `LWD`, `MHHW`, `MHW`, `MTL`, `MSL`, `MLW`, `MLLW`, `NAVD`, `STND` (case-insensitive). **Required** for water-level products.                                                         |
+| `units`     | `metric`, `english`                                                                                                                                                                                 |
+| `time_zone` | `gmt`, `lst`, `lst_ldt`                                                                                                                                                                             |
+| `bin_num`   | Integer. **Required** for `currents` and `currents_predictions`. Find values on each station's info page.                                                                                           |
+| `interval`  | Product-specific. `predictions`: `h`, `1`, `5`, `10`, `15`, `30`, `60`, `hilo`. `currents`: `6`, `h`. `currents_predictions`: `h`, `1`, `6`, `10`, `30`, `60`, `max_slack`. Forbidden on `water_level`, `hourly_height`, `one_minute_water_level`. |
 
-### TODO
-Click [here](https://github.com/GClunies/noaa_coops/issues) for a list of existing issues and to submit a new one.
+### Accepted date formats
 
-### Contribution
-Contributions are welcome, feel free to submit a pull request.
+`begin_date` and `end_date` accept any of:
+
+- `"20150101"` — `%Y%m%d`
+- `"20150101 12:34"` — `%Y%m%d %H:%M`
+- `"01/15/2015"` — `%m/%d/%Y`
+- `"01/15/2015 23:59"` — `%m/%d/%Y %H:%M`
+
+## API etiquette
+
+NOAA's CO-OPS APIs are public and free. There are no enforced rate limits but
+please be reasonable — avoid tight loops against a single station and cache
+results when you can. This library uses connection pooling and automatic
+retries on transient failures (429 / 5xx) via a module-level
+`requests.Session`.
+
+## Contributing
+
+Bug reports, feature requests, and PRs welcome. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for dev-environment setup and the release
+workflow.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Supported on Python **3.10, 3.11, 3.12, and 3.13**.
 uv add noaa-coops
 ```
 
+Or with pip:
+
+```bash
+pip install noaa-coops
+```
+
 ## Getting started
 
 ### Stations

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ search by bounding box:
 ...     lon_coords=[-74.4751, -73.7432],
 ... )
 >>> stations
-['8516945', '8518750', '8519483', '8531680']
+['8516945', '8518750', '8531680']
 >>> Station(id="8516945").name
 'Kings Point'
 ```
@@ -64,7 +64,7 @@ also promoted to top-level attributes on the `Station` object:
 >>> seattle.state
 'WA'
 >>> seattle.lat_lon
-{'lat': 47.601944, 'lon': -122.339167}
+{'lat': 47.60264, 'lon': -122.3393}
 ```
 
 ### Data inventory

--- a/noaa_coops/_http.py
+++ b/noaa_coops/_http.py
@@ -37,6 +37,10 @@ _DEFAULT_RETRY = Retry(
     raise_on_status=False,
 )
 
+# SOAP variant: identical policy, but also retries POST since the
+# DataInventory service is read-only and idempotent despite using POST.
+_SOAP_RETRY = _DEFAULT_RETRY.new(allowed_methods=frozenset(["GET", "POST"]))
+
 
 def _build_session() -> requests.Session:
     """Construct the module-level session. Factored out so tests can rebuild it."""
@@ -47,5 +51,17 @@ def _build_session() -> requests.Session:
     return session
 
 
+def _build_soap_session() -> requests.Session:
+    """Build a session that also retries POST — required for SOAP."""
+    session = requests.Session()
+    adapter = HTTPAdapter(max_retries=_SOAP_RETRY)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
 _SESSION: requests.Session = _build_session()
 """Module-level HTTP session used by every request in this package."""
+
+_SOAP_SESSION: requests.Session = _build_soap_session()
+"""Session used exclusively by the zeep SOAP transport for DataInventory."""

--- a/noaa_coops/station.py
+++ b/noaa_coops/station.py
@@ -18,7 +18,7 @@ import zeep
 
 from noaa_coops._endpoints import DATA_GETTER_URL, INVENTORY_WSDL_URL
 from noaa_coops._exceptions import COOPSAPIError
-from noaa_coops._http import DEFAULT_TIMEOUT, _SESSION
+from noaa_coops._http import DEFAULT_TIMEOUT, _SESSION, _SOAP_SESSION
 from noaa_coops._metadata import populate_metadata
 from noaa_coops._parsing import normalize_data_frame, parse_known_date_formats
 from noaa_coops._products import build_request_params, validate_params
@@ -96,7 +96,8 @@ class Station:
         coverage, so this path uses SOAP. Best-effort: failures degrade to
         an empty dict and log a warning (see :meth:`__init__`).
         """
-        client = zeep.Client(wsdl=INVENTORY_WSDL_URL)
+        transport = zeep.Transport(session=_SOAP_SESSION)
+        client = zeep.Client(wsdl=INVENTORY_WSDL_URL, transport=transport)
         response = client.service.getDataInventory(self.id)
         # zeep marshals SOAP complex types into CompoundValue objects that
         # support `[]` subscript but NOT `.get()`. Use subscript + catch


### PR DESCRIPTION
## Summary

Final tier of the modernization effort, plus a small follow-up reliability fix. Originally billed as pure docs; expanded late in review to include a retrying SOAP session (see *Added — reliability* below) after flakiness on NOAA's `DataInventory` endpoint was observed while verifying README examples. All 72 tests pass unchanged.

## Changes

### `README.md`
- Added **CI**, **license**, **Ruff**, and **pre-commit.ci** badges.
- Replaced the three install examples (pip / poetry / uv) with `uv add noaa-coops` — then added a `pip install noaa-coops` fallback right below it so non-uv users aren't stuck.
- Added **Supported Python versions** (3.10–3.13) to match the current floor.
- Added a **Supported arguments** reference table enumerating valid values for `product`, `datum`, `units`, `time_zone`, `bin_num`, `interval`.
- Added **Accepted date formats** reference.
- Added **API etiquette** section documenting the retry behavior + the partial-failure `RuntimeWarning` / `df.attrs["missing_blocks"]` contract.
- Replaced the "Development / Requirements" + "TODO" sections with a single **Contributing** link to `CONTRIBUTING.md`.
- Refreshed example output to match live NOAA responses (bbox example now returns 3 stations, `lat_lon` values updated) — verified end-to-end against the live API.

### `CONTRIBUTING.md` (new)
Dev environment setup (`uv sync --locked --all-extras --group dev`), test workflow (default offline / `-m live` / cassette re-recording), lint/format/typecheck commands, PR checklist, and the manual release process (bump `__version__` → PR → merge → Actions "Test Publish" → Actions "Publish").

### `CHANGELOG.md` (new)
[Keep a Changelog](https://keepachangelog.com/) format. `[Unreleased]` placeholder + a full `[0.5.0]` entry documenting every user-visible change from Tiers 1–4:
- Added: retry-enabled session, warn-and-continue, PRODUCTS registry, `COOPSAPIError` public export, offline cassettes, nightly canary, publish workflows, Dependabot, pre-commit.
- Changed: build backend to hatchling, CI to uv, HTTP timeouts, narrower `except`, internal module split, PEP 621 migration, `data_inventory` always-set sentinel.
- Fixed: O(n²) concat, silent KeyError in inventory, UnboundLocalError in date parser, stale `--cov=reflekt`.
- Removed: Python 3.9, dead config files, the `JRubics/poetry-publish` action.

`[Unreleased]` also captures the SOAP retry change below.

### `CITATION.cff`
- `license: LICENSE` → `license: Apache-2.0` (proper SPDX identifier).
- Added `version: "0.5.0"`.

### `.github/ISSUE_TEMPLATE/{bug_report,feature_request}.yml` (new)
Structured forms so inbound bug reports have reproduction + version info consistently.

### `.github/pull_request_template.md` (new)
PR checklist covering pytest, ruff, mypy, test coverage, and CHANGELOG updates.

### Added — reliability

**Retrying SOAP session for `DataInventory`.** Testing the README examples end-to-end surfaced a transient failure mode: NOAA's legacy SOAP endpoint occasionally returns HTTP 200 with an empty body, which zeep rejects as malformed XML. The graceful-degradation path in `Station.__init__` was correctly logging a warning and setting `data_inventory = {}` — but the request itself wasn't being retried, even though the REST path had retry coverage for 429/5xx.

Fix:
- New `_SOAP_RETRY` policy in `noaa_coops/_http.py` — identical to the existing `_DEFAULT_RETRY` but also retries POST (SOAP uses POST, and `getDataInventory` is read-only/idempotent).
- New `_SOAP_SESSION` built on that policy, kept separate from `_SESSION` so the REST path keeps its GET-only retry semantics (standard REST idempotency).
- `Station.get_data_inventory` now passes `zeep.Transport(session=_SOAP_SESSION)` into the `zeep.Client` so SOAP calls ride the retrying adapter.

This doesn't fix the empty-body-200 case directly (urllib3's Retry keys off status codes, not content), but it does cover the more common transient 429/5xx failures and makes SOAP behavior consistent with REST. The existing graceful-degradation fallback remains as the final safety net.

## Verification

- [x] `uv run pytest` — 72 passed, 1 deselected (nightly live canary)
- [x] All README code examples run end-to-end against live NOAA (Station construction, bbox search, metadata attributes, `data_inventory`, `get_data` water_level, all four accepted date formats)
- [x] SOAP retry session config verified (`allowed_methods={GET, POST}`, separate session object from `_SESSION`)
- [x] Docs render sensibly on GitHub

## Releasing 0.5.0

After this merges, `master` is the complete 0.5.0 release. To ship it:

1. Actions → **Test Publish** → *Run workflow* → verifies the wheel installs from TestPyPI.
2. Actions → **Publish** → *Run workflow* → publishes to PyPI, tags `v0.5.0`, creates a GitHub Release with the auto-changelog.

No version bump needed — `noaa_coops/__init__.py` already reads `0.5.0`.