### PR TITLE
ci: fix TestPyPI verify with unsafe-best-match index strategy

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -78,5 +78,5 @@ jobs:
         run: |
           sleep 10
           uv venv /tmp/verify-env
-          uv pip install --python /tmp/verify-env/bin/python --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ noaa-coops==${{ needs.validate.outputs.version }}
+          uv pip install --python /tmp/verify-env/bin/python --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ --index-strategy unsafe-best-match noaa-coops==${{ needs.validate.outputs.version }}
           /tmp/verify-env/bin/python -c "from noaa_coops import __version__; assert __version__ == '${{ needs.validate.outputs.version }}', f'Version mismatch: {__version__}'"


### PR DESCRIPTION
## Summary
- TestPyPI verify step in `test-publish.yml` was failing because uv's default `first-index` strategy only considers versions from the first index where a package is found. Since `noaa-coops` exists on PyPI, uv refused to check TestPyPI for the new version.
- Added `--index-strategy unsafe-best-match` so uv considers versions across both indexes. Safe here since the version is pinned exactly.

Failing run: https://github.com/GClunies/noaa_coops/actions/runs/24753464998/job/72421544646

## Test plan
- [ ] Re-run the Test Publish workflow and confirm the verify step installs the freshly published TestPyPI version

🤖 Generated with [Claude Code](https://claude.com/claude-code)