### PR TITLE
chore: update master references to main

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   pull_request:
-    branches: [main, master]
+    branches: [main]
   push:
-    branches: [main, master]
+    branches: [main]
 
 jobs:
   lint:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Releases are cut manually via the GitHub Actions UI.
 1. Bump `__version__` in `noaa_coops/__init__.py` (e.g. `0.5.0` → `0.6.0`).
 2. Update `CHANGELOG.md` — move the **Unreleased** section under the new
    version with today's date, and start a fresh `## [Unreleased]` header.
-3. PR, review, merge to `master`.
+3. PR, review, merge to `main`.
 4. Actions → **Test Publish** → *Run workflow*. Confirms the wheel installs
    cleanly from TestPyPI.
 5. Actions → **Publish** → *Run workflow*. Publishes to PyPI, creates the

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![CI](https://github.com/GClunies/noaa_coops/actions/workflows/pull_request.yml/badge.svg)](https://github.com/GClunies/noaa_coops/actions/workflows/pull_request.yml)
 [![PyPI](https://img.shields.io/pypi/v/noaa-coops.svg)](https://pypi.python.org/pypi/noaa-coops)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/noaa-coops.svg)](https://pypi.python.org/pypi/noaa-coops)
-[![License: Apache 2.0](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](https://github.com/GClunies/noaa_coops/blob/master/LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](https://github.com/GClunies/noaa_coops/blob/main/LICENSE)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/GClunies/noaa_coops/master.svg)](https://results.pre-commit.ci/latest/github/GClunies/noaa_coops/master)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/GClunies/noaa_coops/main.svg)](https://results.pre-commit.ci/latest/github/GClunies/noaa_coops/main)
 
 A Python wrapper for the NOAA CO-OPS Tides & Currents
 [Data](https://tidesandcurrents.noaa.gov/api/) and


### PR DESCRIPTION
## Summary
- Update CI workflow triggers (`pull_request.yml`) to target `main` only
- Update `README.md` badge links (LICENSE, pre-commit.ci) from `master` → `main`
- Update `CONTRIBUTING.md` release process to reference `main`

Follow-up to renaming the default branch from `master` to `main`.

## Test plan
- [ ] CI runs on this PR (verifies the `pull_request.yml` trigger still fires)
- [ ] README badges render correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)