### PR TITLE
ci: make TestPyPI publish idempotent and fail fast on collisions

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -34,6 +34,16 @@ jobs:
             exit 1
           fi
 
+      - name: Check version not already on TestPyPI
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          STATUS=$(curl -sS -o /dev/null -w "%{http_code}" "https://test.pypi.org/pypi/noaa-coops/$VERSION/json")
+          if [ "$STATUS" = "200" ]; then
+            echo "::error::Version $VERSION is already published to TestPyPI. Bump the version in noaa_coops/__init__.py."
+            exit 1
+          fi
+          echo "Version $VERSION is not yet on TestPyPI (HTTP $STATUS)."
+
   test:
     needs: validate
     runs-on: ubuntu-latest
@@ -74,6 +84,7 @@ jobs:
         with:
           password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
       - name: Verify install from TestPyPI
         run: |
           sleep 10


### PR DESCRIPTION
## Summary
The `Test Publish` workflow failed with `400 File already exists` when re-dispatched against an already-published version ([run](https://github.com/GClunies/noaa_coops/actions/runs/24754907927/job/72425992138)). The failure surfaced deep in the publish step with a raw HTML error page. This change makes the workflow fail fast with a clear message, and makes the actual upload idempotent for partial-upload recovery.

## Changes
- Add a pre-flight step in the `validate` job that queries `https://test.pypi.org/pypi/noaa-coops/$VERSION/json` and exits with a friendly "bump the version" error when the version is already published.
- Set `skip-existing: true` on the `pypa/gh-action-pypi-publish` step so a retry after a partial upload (e.g. `.whl` succeeded but `.tar.gz` failed) doesn't re-fail on the already-uploaded file.