### PR TITLE
fix: raise COOPSAPIError on non-200 mdapi responses

### DIFF
--- a/noaa_coops/_metadata.py
+++ b/noaa_coops/_metadata.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from noaa_coops._endpoints import METADATA_BASE_URL
+from noaa_coops._exceptions import COOPSAPIError
 from noaa_coops._http import DEFAULT_TIMEOUT, _SESSION
 
 if TYPE_CHECKING:
@@ -68,6 +69,16 @@ def populate_metadata(station: Station, units: str) -> None:
         f"?units={units}"
     )
     response = _SESSION.get(url, timeout=DEFAULT_TIMEOUT)
+
+    # NOAA's mdapi occasionally 5xx's after retries are exhausted (504s during
+    # the nightly canary). Surface that as COOPSAPIError instead of a
+    # confusing JSONDecodeError from trying to parse an HTML error page.
+    if response.status_code != 200:
+        raise COOPSAPIError(
+            f"Failed to fetch station metadata for id={station.id}. "
+            f"Status code: {response.status_code}. Reason: {response.reason}"
+        )
+
     payload = response.json()
     md = payload["stations"][0]
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -136,6 +136,37 @@ def test_bbox_request_retries_on_transient_failure() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Metadata endpoint surfaces 5xx as COOPSAPIError, not JSONDecodeError
+# ---------------------------------------------------------------------------
+
+
+METADATA_URL_RE = re.compile(
+    r"https://api\.tidesandcurrents\.noaa\.gov/mdapi/prod/webapi/stations/.*"
+)
+
+
+@responses.activate
+def test_metadata_504_raises_coops_error_not_json_error() -> None:
+    """A NOAA mdapi 504 after retries surfaces as COOPSAPIError, not JSONDecodeError.
+
+    Regression for the nightly canary that returned an HTML 504 body and
+    tripped ``response.json()`` with a confusing decode error.
+    """
+    # More than Retry.total=3 attempts; all 504 with an HTML body.
+    for _ in range(5):
+        responses.add(
+            responses.GET,
+            METADATA_URL_RE,
+            status=504,
+            body="<html><body>504 Gateway Time-out</body></html>",
+            content_type="text/html",
+        )
+
+    with pytest.raises(COOPSAPIError, match="504"):
+        nc.Station(id="9447130")
+
+
+# ---------------------------------------------------------------------------
 # Session sanity
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
The nightly canary failed with a cryptic `JSONDecodeError` when NOAA's mdapi returned HTTP 504 — the code called `response.json()` on an HTML error body. This change surfaces mdapi HTTP errors as `COOPSAPIError` with the real status/reason, matching the pattern already used in `api.py` and `station.py`.

## Changes
- `noaa_coops/_metadata.py`: guard `response.json()` with a `status_code != 200` check; raise `COOPSAPIError` otherwise.
- `tests/test_retry.py`: regression test that feeds an HTML 504 to the mdapi and asserts `COOPSAPIError` is raised (not `JSONDecodeError`).

Does not change the nightly canary outcome when NOAA is actually down — just makes the failure legible. Canary run that motivated this: https://github.com/GClunies/noaa_coops/actions/runs/24764160796/job/72454353249