### PR TITLE
fix: validate affil, projection_year, report_year, and year in DPAPI requests

### DIFF
--- a/noaa_coops/_derived.py
+++ b/noaa_coops/_derived.py
@@ -69,6 +69,19 @@ SLR_PROJECTION_SCENARIOS: frozenset[str] = frozenset(
     }
 )
 
+#: `affil` options — sea_level_trends, slr_projections, slr_projection_offsets.
+AFFIL_OPTIONS: frozenset[str] = frozenset({"US", "Global"})
+
+#: API products that accept `affil`.
+AFFIL_PRODUCTS: frozenset[str] = frozenset(
+    {"sealvltrends", "slr_projections", "slr_projectionOffsets"}
+)
+
+#: API products that accept `report_year`.
+REPORT_YEAR_PRODUCTS: frozenset[str] = frozenset(
+    {"slr_projections", "slr_projectionOffsets"}
+)
+
 #: Public product name -> NOAA DPAPI product name.
 #: `Station.get_derived_product` accepts and returns the public name; only
 #: `build_dpapi_url` needs to know the underlying API spelling. Products
@@ -111,6 +124,9 @@ def validate_params(
     level_type: Optional[str] = None,
     scenario: Optional[str] = None,
     year: Optional[int] = None,
+    affil: Optional[str] = None,
+    projection_year: Optional[int] = None,
+    report_year: Optional[int] = None,
 ) -> None:
     """Validate arguments before any DPAPI request is made.
 
@@ -194,12 +210,50 @@ def validate_params(
             )
 
     if year is not None:
+        if api_product not in HTF_PRODUCTS:
+            raise ValueError(
+                f"`year` is only supported for HTF products, not '{product}'."
+            )
         if isinstance(year, bool) or not isinstance(year, int):
             raise ValueError(f"`year` must be an int, got {type(year).__name__}.")
         current_year = datetime.date.today().year
         if not (1800 <= year <= current_year):
             raise ValueError(
                 f"Invalid year '{year}'. Must be between 1800 and {current_year}."
+            )
+
+    if affil is not None:
+        if api_product not in AFFIL_PRODUCTS:
+            raise ValueError(
+                "`affil` is only supported for sea_level_trends, slr_projections, "
+                f"and slr_projection_offsets, not '{product}'."
+            )
+        if affil not in AFFIL_OPTIONS:
+            raise ValueError(
+                f"Invalid affil '{affil}'. Must be one of: {sorted(AFFIL_OPTIONS)}"
+            )
+
+    if projection_year is not None:
+        if api_product != "slr_projections":
+            raise ValueError(
+                f"`projection_year` is only supported for slr_projections, "
+                f"not '{product}'."
+            )
+        if isinstance(projection_year, bool) or not isinstance(projection_year, int):
+            raise ValueError(
+                "`projection_year` must be an int, "
+                f"got {type(projection_year).__name__}."
+            )
+
+    if report_year is not None:
+        if api_product not in REPORT_YEAR_PRODUCTS:
+            raise ValueError(
+                "`report_year` is only supported for slr_projections and "
+                f"slr_projection_offsets, not '{product}'."
+            )
+        if isinstance(report_year, bool) or not isinstance(report_year, int):
+            raise ValueError(
+                f"`report_year` must be an int, got {type(report_year).__name__}."
             )
 
 
@@ -562,6 +616,9 @@ def get_derived_product(
         level_type=level_type,
         scenario=scenario,
         year=year,
+        affil=affil,
+        projection_year=projection_year,
+        report_year=report_year,
     )
 
     url = build_dpapi_url(

--- a/tests/test_derived_product_validators.py
+++ b/tests/test_derived_product_validators.py
@@ -1,14 +1,17 @@
 """Unit tests for the Derived Product API's parameter validator.
 
-These exercise `_derived.validate_params` directly. No HTTP, no mocks --
-the validator raises ValueError before any network call. See
-`test_validators.py` for the equivalent tests against `_products.validate_params`
+These exercise `_derived.validate_params` directly (no HTTP, no mocks --
+the validator raises ValueError before any network call), plus one
+public-boundary regression test that proves `get_derived_product` forwards
+to the validator before touching the network. See `test_validators.py` for
+the equivalent tests against `_products.validate_params`
 (the non-derived Data API).
 """
 
 from __future__ import annotations
 
 import pytest
+import noaa_coops._derived as _derived
 from noaa_coops._derived import validate_params
 
 BASE = {
@@ -62,8 +65,11 @@ BASE = {
         ({"product": "htf_annual", "year": "2020"}, "must be an int"),
         ({"product": "sea_level_trends", "year": 2020}, "only supported for HTF"),
         ({"product": "slr_projections", "year": 2020}, "only supported for HTF"),
-        ({"product": "sea_level_trends", "affil": "us"}, "Invalid affil"),
-        ({"product": "slr_projections", "affil": "bogus"}, "Invalid affil"),
+        ({"product": "sea_level_trends", "affil": "us"}, r"Invalid affil.*Global.*US"),
+        (
+            {"product": "slr_projections", "affil": "bogus"},
+            r"Invalid affil.*Global.*US",
+        ),
         (
             {"product": "htf_annual", "affil": "US"},
             "`affil` is only supported",
@@ -82,6 +88,14 @@ BASE = {
         ),
         (
             {"product": "slr_projections", "report_year": "2022"},
+            "`report_year` must be an int",
+        ),
+        (
+            {"product": "slr_projections", "projection_year": True},
+            "`projection_year` must be an int",
+        ),
+        (
+            {"product": "slr_projections", "report_year": True},
             "`report_year` must be an int",
         ),
     ],
@@ -136,3 +150,27 @@ def test_valid_derived_params_accepted(overrides):
     where applicable, passes validation with no error."""
     kwargs = {**BASE, **overrides}
     validate_params(**kwargs)  # should not raise
+
+
+class _ExplodingSession:
+    """Fails the test if any HTTP request is attempted."""
+
+    def get(self, *args, **kwargs):
+        raise AssertionError("HTTP request was made before validation failed")
+
+
+class _FakeStation:
+    id = "9447130"
+
+
+def test_get_derived_product_validates_before_http(monkeypatch):
+    """Public-boundary regression: get_derived_product must forward params to
+    validate_params and raise before any HTTP request. Removing the validator
+    forwarding in _derived.get_derived_product must fail this test."""
+    monkeypatch.setattr(_derived, "_SESSION", _ExplodingSession())
+    with pytest.raises(ValueError, match=r"Invalid affil.*Global.*US"):
+        _derived.get_derived_product(
+            station=_FakeStation(),
+            product="sea_level_trends",
+            affil="bogus",
+        )

--- a/tests/test_derived_product_validators.py
+++ b/tests/test_derived_product_validators.py
@@ -60,6 +60,30 @@ BASE = {
         ({"product": "htf_annual", "year": 1750}, "Invalid year"),
         ({"product": "htf_annual", "year": 3000}, "Invalid year"),
         ({"product": "htf_annual", "year": "2020"}, "must be an int"),
+        ({"product": "sea_level_trends", "year": 2020}, "only supported for HTF"),
+        ({"product": "slr_projections", "year": 2020}, "only supported for HTF"),
+        ({"product": "sea_level_trends", "affil": "us"}, "Invalid affil"),
+        ({"product": "slr_projections", "affil": "bogus"}, "Invalid affil"),
+        (
+            {"product": "htf_annual", "affil": "US"},
+            "`affil` is only supported",
+        ),
+        (
+            {"product": "sea_level_trends", "projection_year": 2050},
+            "`projection_year` is only supported for slr_projections",
+        ),
+        (
+            {"product": "slr_projections", "projection_year": "2050"},
+            "`projection_year` must be an int",
+        ),
+        (
+            {"product": "sea_level_trends", "report_year": 2022},
+            "`report_year` is only supported",
+        ),
+        (
+            {"product": "slr_projections", "report_year": "2022"},
+            "`report_year` must be an int",
+        ),
     ],
 )
 def test_validate_params_rejects_bad_input(overrides, match):
@@ -99,6 +123,12 @@ def test_validate_params_rejects_bad_input(overrides, match):
         {"product": "extreme_water_levels", "level_type": "low"},
         {"product": "htf_annual", "year": 2001},
         {"product": "htf_annual", "year": 1800},
+        {"product": "sea_level_trends", "affil": "US"},
+        {"product": "slr_projections", "affil": "Global"},
+        {"product": "slr_projection_offsets", "affil": "US"},
+        {"product": "slr_projections", "projection_year": 2050},
+        {"product": "slr_projections", "report_year": 2022},
+        {"product": "slr_projection_offsets", "report_year": 2022},
     ],
 )
 def test_valid_derived_params_accepted(overrides):


### PR DESCRIPTION
## Summary

`_derived.validate_params` now checks every DPAPI parameter before a network call:

- `affil` outside `{"US", "Global"}` raises `ValueError` and names the valid values.
- `affil` on a product other than `sea_level_trends`, `slr_projections`, or `slr_projection_offsets` raises `ValueError`.
- `projection_year` on a product other than `slr_projections` raises `ValueError`. Non-int values raise `ValueError`.
- `report_year` on a product other than `slr_projections` or `slr_projection_offsets` raises `ValueError`. Non-int values raise `ValueError`.
- `year` on a non-HTF product raises `ValueError` instead of being dropped by `build_dpapi_url`.

This matches the existing handling of `detail`, `level_type`, and `scenario`.

Closes #112

## Tests

Added cases to `tests/test_derived_product_validators.py` for each rejection and for valid inputs.

`uv run pytest tests/test_derived_product_validators.py tests/test_derived_products.py` — 58 passed.