### PR TITLE
fix: raise clear COOPSAPIError when a DPAPI response has no list to parse

### DIFF
--- a/noaa_coops/_derived.py
+++ b/noaa_coops/_derived.py
@@ -457,12 +457,12 @@ def parse_dpapi_response(
     everything else falls through to a generic json_normalize on whichever
     top-level key holds a list.
     """
-    product = _to_api_product(product)
-    if product == "extrfa":
+    api_product = _to_api_product(product)
+    if api_product == "extrfa":
         df = _parse_extrfa(payload)
-    elif product == "sealvltrends":
+    elif api_product == "sealvltrends":
         df = _parse_sealvltrends(payload, detail)
-    elif product == "extremewaterlevels":
+    elif api_product == "extremewaterlevels":
         df = _parse_extremewaterlevels(payload, level_type)
     else:
         top_level_key = next(

--- a/noaa_coops/_derived.py
+++ b/noaa_coops/_derived.py
@@ -465,7 +465,14 @@ def parse_dpapi_response(
     elif product == "extremewaterlevels":
         df = _parse_extremewaterlevels(payload, level_type)
     else:
-        top_level_key = next(k for k, v in payload.items() if isinstance(v, list))
+        top_level_key = next(
+            (k for k, v in payload.items() if isinstance(v, list)), None
+        )
+        if top_level_key is None:
+            raise COOPSAPIError(
+                f"DPAPI response for product '{product}' contains no list "
+                f"value to parse; payload keys: {list(payload)}"
+            )
         df = pd.json_normalize(payload[top_level_key])
 
     return df.reset_index(drop=True)

--- a/tests/test_derived_products.py
+++ b/tests/test_derived_products.py
@@ -176,5 +176,5 @@ def test_parse_dpapi_response_listless_payload_raises_coops_api_error():
     """A payload with no list value raises COOPSAPIError, not StopIteration."""
     payload = {"error": {"message": "No data was found"}, "count": 0}
 
-    with pytest.raises(COOPSAPIError, match=r"high_tide_flooding_annual.*error.*count"):
-        parse_dpapi_response(payload, product="high_tide_flooding_annual")
+    with pytest.raises(COOPSAPIError, match=r"slr_projection_offsets.*error.*count"):
+        parse_dpapi_response(payload, product="slr_projection_offsets")

--- a/tests/test_derived_products.py
+++ b/tests/test_derived_products.py
@@ -16,6 +16,8 @@ import pytest
 
 import noaa_coops as nc
 from noaa_coops._derived import build_dpapi_url
+from noaa_coops._derived import parse_dpapi_response
+from noaa_coops._exceptions import COOPSAPIError
 
 DERIVED_PRODUCT_MATRIX = [
     pytest.param(
@@ -168,3 +170,11 @@ def test_sea_level_trends_monthly_means() -> None:
     }
     assert not df.empty
     assert set(df.columns) == expected_cols
+
+
+def test_parse_dpapi_response_listless_payload_raises_coops_api_error():
+    """A payload with no list value raises COOPSAPIError, not StopIteration."""
+    payload = {"error": {"message": "No data was found"}, "count": 0}
+
+    with pytest.raises(COOPSAPIError, match=r"high_tide_flooding_annual.*error.*count"):
+        parse_dpapi_response(payload, product="high_tide_flooding_annual")


### PR DESCRIPTION
## Summary

`parse_dpapi_response` raised a bare `StopIteration` when a payload contained no list value (for example, an error body). The fallback `next(...)` now uses a default. When no list value exists, it raises `COOPSAPIError` with the product name and the payload keys.

## Changes

- `noaa_coops/_derived.py`: defaulted `next()` plus a `COOPSAPIError` that names the product and `list(payload)` keys.
- `tests/test_derived_products.py`: unit test that feeds a listless payload and asserts on the error message.

## Verification

`uv run pytest tests/test_derived_products.py tests/test_derived_product_validators.py` — 44 passed.

Closes #113