### PR TITLE
fix: raise KeyError for unexpected record keys in daily_max_min flattener

### DIFF
--- a/noaa_coops/station.py
+++ b/noaa_coops/station.py
@@ -518,10 +518,20 @@ class Station:
                 flattened_payload = []
                 for item in json_dict["data"]:
                     for key, records in item.items():
+                        if "dailyMin" in key:
+                            record_type = "min"
+                        elif "dailyMax" in key:
+                            record_type = "max"
+                        else:
+                            raise KeyError(
+                                f"Unexpected record key '{key}' in daily_max_min "
+                                "response; expected a key containing 'dailyMax' "
+                                "or 'dailyMin'."
+                            )
                         for record in records:
                             # Standardize the varying NOAA keys using safe fallbacks
                             clean_record = {
-                                "record_type": "min" if "dailyMin" in key else "max",
+                                "record_type": record_type,
                                 "date": record.get(
                                     "date6Min", record.get("dateHourly")
                                 ),

--- a/tests/test_station_products.py
+++ b/tests/test_station_products.py
@@ -141,3 +141,39 @@ def test_datums_rejected_by_get_data() -> None:
             product="datums",
             datum="MLLW",
         )
+
+
+def test_daily_max_min_rejects_unexpected_record_key(monkeypatch) -> None:
+    """The daily_max_min flattener maps 'dailyMax'/'dailyMin' keys to
+    record_type 'max'/'min'. Any other key must raise a clear KeyError
+    instead of silently defaulting to 'max'.
+    """
+    from noaa_coops import station as station_mod
+
+    class FakeResponse:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict:
+            return {
+                "data": [
+                    {
+                        "dailyWeird": [
+                            {
+                                "dateHourly": "2015-01-01",
+                                "timeHourly": "09:00",
+                                "valueHourly": 1.0,
+                                "pcCompleteHourly": 100,
+                                "flagHourly": 0,
+                            }
+                        ]
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(
+        station_mod._SESSION, "get", lambda url, timeout: FakeResponse()
+    )
+    station = nc.Station.__new__(nc.Station)  # skip metadata fetch in __init__
+    with pytest.raises(KeyError, match="Unexpected record key 'dailyWeird'"):
+        station._make_api_request("http://fake", product="daily_max_min")


### PR DESCRIPTION
## What

In `Station._make_api_request`, the `daily_max_min` flattener labeled any unexpected record key as `"max"`. It now assigns record types strictly:

- Keys containing `dailyMin` map to `min`.
- Keys containing `dailyMax` map to `max`.
- Any other key raises a clear `KeyError`.

## Tests

- Added `test_daily_max_min_rejects_unexpected_record_key` for the unexpected-key path.
- `uv run pytest tests/`: 145 passed.

Closes #115