### PR TITLE
fix: reject unknown daily max/min record keys

### DIFF
--- a/noaa_coops/station.py
+++ b/noaa_coops/station.py
@@ -518,10 +518,18 @@ class Station:
                 flattened_payload = []
                 for item in json_dict["data"]:
                     for key, records in item.items():
+                        if "dailyMax" in key:
+                            record_type = "max"
+                        elif "dailyMin" in key:
+                            record_type = "min"
+                        else:
+                            raise KeyError(
+                                f"Unexpected daily_max_min record key: {key!r}"
+                            )
                         for record in records:
                             # Standardize the varying NOAA keys using safe fallbacks
                             clean_record = {
-                                "record_type": "min" if "dailyMin" in key else "max",
+                                "record_type": record_type,
                                 "date": record.get(
                                     "date6Min", record.get("dateHourly")
                                 ),

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -165,6 +165,66 @@ def test_make_api_request_passes_timeout() -> None:
     _assert_timeout(mock_get)
 
 
+@pytest.mark.parametrize(
+    ("record_key", "expected_type"),
+    [
+        pytest.param("dailyMax6Min", "max", id="maximum"),
+        pytest.param("dailyMin6Min", "min", id="minimum"),
+    ],
+)
+def test_daily_max_min_record_type_is_explicit(
+    record_key: str, expected_type: str
+) -> None:
+    """Known NOAA record keys map to their corresponding record type."""
+    station = _bare_station()
+    mock_resp = MagicMock(spec=requests.Response)
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "data": [
+            {
+                record_key: [
+                    {
+                        "date6Min": "2026-01-01",
+                        "time6Min": "00:00",
+                        "value6Min": "1.0",
+                    }
+                ]
+            }
+        ]
+    }
+
+    with patch("noaa_coops.station._SESSION.get", return_value=mock_resp):
+        result = station._make_api_request("https://example.com/data", "daily_max_min")
+
+    assert result.loc[0, "record_type"] == expected_type
+
+
+def test_daily_max_min_rejects_an_unexpected_record_key() -> None:
+    """Unknown NOAA keys fail explicitly instead of being mislabeled as maxima."""
+    station = _bare_station()
+    mock_resp = MagicMock(spec=requests.Response)
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "data": [
+            {
+                "dailyAverage6Min": [
+                    {
+                        "date6Min": "2026-01-01",
+                        "time6Min": "00:00",
+                        "value6Min": "1.0",
+                    }
+                ]
+            }
+        ]
+    }
+
+    with (
+        patch("noaa_coops.station._SESSION.get", return_value=mock_resp),
+        pytest.raises(KeyError, match="Unexpected daily_max_min record key"),
+    ):
+        station._make_api_request("https://example.com/data", "daily_max_min")
+
+
 # ---------------------------------------------------------------------------
 # Narrow-exception tests (no more bare `except:`)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #115.

## What changed

- classify `dailyMax` and `dailyMin` response keys explicitly
- raise a clear `KeyError` for an unexpected `daily_max_min` record key instead of silently labeling it as a maximum
- add unit coverage for both documented key families and the unexpected-key path

## Verification

- regression test failed on current `main` before the fix
- focused tests: 3 passed
- complete offline suite: 147 passed, 1 live test deselected
- Ruff check and formatting pass for the changed files
- mypy passes for all 10 source files
- `git diff --check` passes
